### PR TITLE
Improved table visibility rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Improved table visibility rules: bare string patterns (e.g., `"api_keys"`) now match table names across all schemas in PostgreSQL, not just nil/empty schemas. This provides a more intuitive API where `"api_keys"` blocks the table in any schema, while `{"public", "api_keys"}` blocks it only in the public schema.
+
 ## [0.3.2] - 2025-08-25
 
 - Change `statement` col from varchar to text

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Lotus is a lightweight SQL query runner and storage library for Elixir applicati
 - [ ] Query result caching mechanisms
 - [ ] Export functionality for query results (CSV, JSON)
 - [ ] MySQL support
+- [ ] Column-level visibility and access control
 - [x] Multi-database support (PostgreSQL, SQLite)
 - [x] Table visibility and access controls
 - [x] Query templates with parameter substitution using `{{var}}` placeholders

--- a/guides/schema-introspection.md
+++ b/guides/schema-introspection.md
@@ -476,12 +476,18 @@ Configure table visibility rules to ensure schema introspection only shows allow
 config :lotus,
   table_visibility: %{
     default: [
-      deny: ["api_keys", "user_passwords", "audit_logs"]
+      # Bare strings block tables across ALL schemas
+      deny: [
+        "api_keys",         # Blocks api_keys in any schema
+        "user_passwords",   # Blocks user_passwords in any schema
+        "audit_logs"        # Blocks audit_logs in any schema
+      ]
     ],
     reporting: [
       allow: [
         {"reporting", ~r/.*/},  # All reporting schema tables
-        {"public", "users"}      # Specific public tables
+        {"public", "users"},    # Specific public.users table
+        "summaries"             # Allow 'summaries' table in any schema
       ]
     ]
   }

--- a/lib/lotus/visibility.ex
+++ b/lib/lotus/visibility.ex
@@ -3,6 +3,13 @@ defmodule Lotus.Visibility do
   Table visibility filtering for Lotus.
 
   Built-ins deny common metadata/system relations; user config can add allow/deny.
+
+  ## Rule Formats
+
+  - `{"schema", "table"}` - Matches specific schema.table
+  - `"table"` - Matches table name in any schema (convenience for blocking across all schemas)
+  - `{~r/pattern/, "table"}` - Matches table in schemas matching the regex
+  - `{"schema", ~r/pattern/}` - Matches tables matching regex in specific schema
   """
 
   alias Lotus.Config
@@ -87,7 +94,9 @@ defmodule Lotus.Visibility do
         pattern_match?(schema_pat, s) and pattern_match?(table_pat, t)
 
       tbl when is_binary(tbl) ->
-        s in [nil, ""] and pattern_match?(tbl, t)
+        # Bare string matches table name regardless of schema
+        # This makes "api_keys" match both {nil, "api_keys"} and {"public", "api_keys"}
+        pattern_match?(tbl, t)
 
       other ->
         other == {s, t}


### PR DESCRIPTION
bare string patterns (e.g., ) now match table names across all schemas in PostgreSQL, not just nil/empty schemas