### PR TITLE
Refactor adapters into behaviour with placeholder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
+
+### Added
+- Introduced `Lotus.Adapter` behaviour with dedicated implementations for PostgreSQL, SQLite, and Default
+- Added `param_placeholder/3` callback to adapter behaviour for generating database-specific SQL parameter placeholders
+- Added `handled_errors/0` callback to allow adapters to declare which exceptions they format
+
+### Changed
+- **BREAKING:** Removed `param_style/1` API in favor of `param_placeholder/4` facade that delegates to adapters
+- Refactored error formatting to delegate based on `handled_errors/0`, ensuring cleaner and more extensible error handling
+- Consolidated adapter tests into a single facade-level `Lotus.AdapterTest` covering all supported databasesd
 
 ## [0.4.0] - 2025-08-26
 

--- a/lib/lotus/adapters/default.ex
+++ b/lib/lotus/adapters/default.ex
@@ -1,0 +1,46 @@
+defmodule Lotus.Adapter.Default do
+  @moduledoc """
+  Default adapter implementation for unsupported or unknown database adapters.
+
+  Provides safe no-op implementations for adapter-specific functions and
+  generic error formatting for database errors.
+  """
+
+  @behaviour Lotus.Adapter
+
+  @impl true
+  @doc "No-op: unsupported adapters cannot enforce read-only mode."
+  def set_read_only(_repo), do: :ok
+
+  @impl true
+  @doc "No-op: unsupported adapters do not implement statement timeouts."
+  def set_statement_timeout(_repo, _ms), do: :ok
+
+  @impl true
+  @doc "No-op: unsupported adapters do not implement search_path."
+  def set_search_path(_repo, _path), do: :ok
+
+  @impl true
+  @doc """
+  Formats common error types into strings. Falls back to `inspect/1`
+  for unknown values.
+  """
+  def format_error(%{__exception__: true} = e), do: Exception.message(e)
+  def format_error(%DBConnection.EncodeError{message: msg}), do: msg
+  def format_error(%ArgumentError{message: msg}), do: msg
+  def format_error(msg) when is_binary(msg), do: msg
+  def format_error(other), do: "Database Error: #{inspect(other)}"
+
+  @impl true
+  @doc """
+  Returns a generic SQL parameter placeholder (`"?"`).
+
+  This keeps the query builder working even for unknown adapters,
+  though actual binding semantics may differ.
+  """
+  def param_placeholder(_idx, _var, _type), do: "?"
+
+  @impl true
+  @doc "The default adapter does not handle any specific exceptions."
+  def handled_errors, do: []
+end

--- a/lib/lotus/adapters/postgres.ex
+++ b/lib/lotus/adapters/postgres.ex
@@ -1,0 +1,50 @@
+defmodule Lotus.Adapter.Postgres do
+  @moduledoc false
+
+  @behaviour Lotus.Adapter
+
+  @impl true
+  def set_read_only(repo) do
+    repo.query!("SET LOCAL transaction_read_only = on")
+    :ok
+  end
+
+  @impl true
+  def set_statement_timeout(repo, timeout_ms) do
+    repo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
+    :ok
+  end
+
+  @impl true
+  def set_search_path(repo, search_path) when is_binary(search_path) do
+    repo.query!("SET LOCAL search_path = #{search_path}")
+    :ok
+  end
+
+  @impl true
+  def format_error(%Postgrex.Error{} = e) do
+    pg = Map.get(e, :postgres)
+
+    cond do
+      is_map(pg) and pg[:code] == :syntax_error and is_binary(pg[:message]) ->
+        "SQL syntax error: #{pg[:message]}"
+
+      is_map(pg) and is_binary(pg[:message]) ->
+        "SQL error: #{pg[:message]}"
+
+      is_binary(Map.get(e, :message)) ->
+        "SQL error: #{Map.get(e, :message)}"
+
+      true ->
+        Exception.message(e)
+    end
+  end
+
+  def format_error(other), do: Lotus.Adapter.Default.format_error(other)
+
+  @impl true
+  def param_placeholder(idx, _var, _type), do: "$#{idx}"
+
+  @impl true
+  def handled_errors, do: [Postgrex.Error]
+end

--- a/lib/lotus/adapters/sqlite.ex
+++ b/lib/lotus/adapters/sqlite.ex
@@ -1,0 +1,50 @@
+defmodule Lotus.Adapter.SQLite3 do
+  @moduledoc false
+
+  @behaviour Lotus.Adapter
+  require Logger
+
+  @impl true
+  def set_read_only(repo) do
+    try do
+      repo.query!("PRAGMA query_only = ON")
+      :ok
+    rescue
+      error in [Exqlite.Error] ->
+        msg = error.message || Exception.message(error)
+
+        if msg =~ "no such pragma" or msg =~ "unknown pragma" do
+          Logger.warning("""
+          SQLite version does not support PRAGMA query_only.
+          Consider opening the connection in read-only mode instead
+          (database=...&mode=ro or database=...&immutable=1).
+          """)
+
+          :ok
+        else
+          reraise error, __STACKTRACE__
+        end
+    end
+  end
+
+  @impl true
+  # No-op: SQLite does not support statement timeouts
+  def set_statement_timeout(_repo, _timeout_ms), do: :ok
+
+  @impl true
+  # No-op: SQLite does not support search_path
+  def set_search_path(_repo, _search_path), do: :ok
+
+  @impl true
+  def format_error(%Exqlite.Error{} = e) do
+    "SQLite Error: " <> (Map.get(e, :message) || Exception.message(e))
+  end
+
+  def format_error(other), do: Lotus.Adapter.Default.format_error(other)
+
+  @impl true
+  def param_placeholder(_idx, _var, _type), do: "?"
+
+  @impl true
+  def handled_errors, do: [Exqlite.Error]
+end


### PR DESCRIPTION
Introduce Lotus.Adapter behaviour with dedicated Postgres, SQLite, and Default implementations.

Add param_placeholder/3 callback for generating adapter-specific SQL parameter placeholders.

Add handled_errors/0 callback so adapters declare which exceptions they handle.

BREAKING: Remove param_style/1 API in favor of param_placeholder/4 facade.

Refactor error formatting to dispatch via handled_errors/0 for cleaner extensibility.

Consolidate adapter tests into single facade-level Lotus.AdapterTest covering all supported databases.