### PR TITLE
Type specific parameter placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.3] - 2025-08-29
+
 ### Enhanced
 - Added type-specific SQL parameter placeholders for MySQL adapter supporting date, datetime, time, number, integer, boolean, and json types
 - Added type-specific SQL parameter placeholders for PostgreSQL adapter supporting date, datetime, time, number, integer, boolean, and json types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Enhanced
+- Added type-specific SQL parameter placeholders for MySQL adapter supporting date, datetime, time, number, integer, boolean, and json types
+- Added type-specific SQL parameter placeholders for PostgreSQL adapter supporting date, datetime, time, number, integer, boolean, and json types
+- Added `extract_variables_from_statement/1` function to extract unique variable names from SQL statements in order of first occurrence
+- Added `get_option_source/1` function to QueryVariable module to determine if options come from query or static sources
+
+### Fixed
+- Added proper type casting in parameter placeholders to ensure correct SQL data type handling across database adapters
+
 ## [0.5.2] - 2025-08-28
 
 ### Enhanced

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -507,9 +507,9 @@ The `options_query` should return two columns:
 
 ### Variable Features
 
-- **Safe substitution**: Variables are converted to database-specific placeholders (`$1, $2` for PostgreSQL, `?` for SQLite)
-- **Structured variables**: Define variables with type, label, and default values for better UI integration
-- **Type support**: Supports text, number, and date types
+- **Safe substitution**: Variables are converted to database-specific placeholders with automatic type casting (`$1::integer` for PostgreSQL, `CAST(? AS SIGNED)` for MySQL, `?` for SQLite)
+- **Structured variables**: Define variables with type, label, and default values for better UI integration  
+- **Type support**: Supports text, number, integer, date, datetime, time, boolean, and json types with automatic database casting
 - **Widget controls**: Specify input or select widgets for UI rendering
 - **Static options**: Use `static_options` for predefined dropdown choices
 - **Dynamic options**: Use `options_query` to populate dropdowns from database queries
@@ -517,6 +517,35 @@ The `options_query` should return two columns:
 - **Runtime override**: Pass `vars:` option to override defaults
 - **Multiple occurrences**: The same variable can appear multiple times and will be bound correctly
 - **Type safety**: Variables are passed as parameters, preventing SQL injection
+
+## Variable Type Casting
+
+Lotus automatically generates type-specific SQL placeholders based on your variable types, ensuring proper data handling across different databases:
+
+### PostgreSQL Type Casting
+- `:integer` → `$1::integer`
+- `:number` → `$1::numeric` 
+- `:date` → `$1::date`
+- `:datetime` → `$1::timestamp`
+- `:time` → `$1::time`
+- `:boolean` → `$1::boolean`
+- `:json` → `$1::jsonb`
+- `:text` (default) → `$1`
+
+### MySQL Type Casting  
+- `:integer` → `CAST(? AS SIGNED)`
+- `:number` → `CAST(? AS DECIMAL)`
+- `:date` → `CAST(? AS DATE)`
+- `:datetime` → `CAST(? AS DATETIME)`
+- `:time` → `CAST(? AS TIME)`
+- `:boolean` → `CAST(? AS UNSIGNED)`
+- `:json` → `CAST(? AS JSON)`
+- `:text` (default) → `?`
+
+### SQLite
+SQLite uses untyped `?` placeholders for all variable types, as it handles type conversion automatically.
+
+This type casting ensures that your data is properly handled by the database engine and can prevent runtime type errors.
 
 ## Error Handling
 

--- a/lib/lotus/adapter.ex
+++ b/lib/lotus/adapter.ex
@@ -29,9 +29,14 @@ defmodule Lotus.Adapter do
   @doc """
   Return the SQL parameter placeholder string for a variable at a given index.
 
+  The placeholder may include database-specific type casting based on the variable type.
+
   Examples of adapter-specific output:
-    * Postgres → `"$1"`, `"$2"`, ...
-    * SQLite   → `"?"`
+    * Postgres → `"$1"` (untyped), `"$1::integer"` (typed)
+    * MySQL    → `"?"` (untyped), `"CAST(? AS SIGNED)"` (typed)
+    * SQLite   → `"?"` (always untyped)
+
+  Supported types for casting: `:date`, `:datetime`, `:time`, `:number`, `:integer`, `:boolean`, `:json`
   """
   @callback param_placeholder(index :: pos_integer(), var :: String.t(), type :: atom() | nil) ::
               String.t()

--- a/lib/lotus/adapters/mysql.ex
+++ b/lib/lotus/adapters/mysql.ex
@@ -39,6 +39,13 @@ defmodule Lotus.Adapter.MySQL do
   def format_error(other), do: Lotus.Adapter.Default.format_error(other)
 
   @impl true
+  def param_placeholder(_idx, _var, :date), do: "CAST(? AS DATE)"
+  def param_placeholder(_idx, _var, :datetime), do: "CAST(? AS DATETIME)"
+  def param_placeholder(_idx, _var, :time), do: "CAST(? AS TIME)"
+  def param_placeholder(_idx, _var, :number), do: "CAST(? AS DECIMAL)"
+  def param_placeholder(_idx, _var, :integer), do: "CAST(? AS SIGNED)"
+  def param_placeholder(_idx, _var, :boolean), do: "CAST(? AS UNSIGNED)"
+  def param_placeholder(_idx, _var, :json), do: "CAST(? AS JSON)"
   def param_placeholder(_idx, _var, _type), do: "?"
 
   @impl true

--- a/lib/lotus/adapters/postgres.ex
+++ b/lib/lotus/adapters/postgres.ex
@@ -45,6 +45,13 @@ defmodule Lotus.Adapter.Postgres do
   def format_error(other), do: Lotus.Adapter.Default.format_error(other)
 
   @impl true
+  def param_placeholder(idx, _var, :date), do: "$#{idx}::date"
+  def param_placeholder(idx, _var, :datetime), do: "$#{idx}::timestamp"
+  def param_placeholder(idx, _var, :time), do: "$#{idx}::time"
+  def param_placeholder(idx, _var, :number), do: "$#{idx}::numeric"
+  def param_placeholder(idx, _var, :integer), do: "$#{idx}::integer"
+  def param_placeholder(idx, _var, :boolean), do: "$#{idx}::boolean"
+  def param_placeholder(idx, _var, :json), do: "$#{idx}::jsonb"
   def param_placeholder(idx, _var, _type), do: "$#{idx}"
 
   @impl true

--- a/lib/lotus/storage/query.ex
+++ b/lib/lotus/storage/query.ex
@@ -102,6 +102,23 @@ defmodule Lotus.Storage.Query do
     end)
   end
 
+  @doc """
+  Extracts unique variable names from an SQL statement in order of first occurrence.
+
+  Variables are identified by the `{{variable_name}}` syntax.
+
+  ## Examples
+
+      iex> Lotus.Storage.Query.extract_variables_from_statement("SELECT * FROM users WHERE id = {{user_id}} AND status = {{status}}")
+      ["user_id", "status"]
+
+      iex> Lotus.Storage.Query.extract_variables_from_statement("SELECT * FROM users WHERE id = {{user_id}} OR id = {{user_id}}")
+      ["user_id"]
+
+      iex> Lotus.Storage.Query.extract_variables_from_statement("SELECT * FROM users")
+      []
+
+  """
   @spec extract_variables_from_statement(String.t()) :: [String.t()]
   def extract_variables_from_statement(statement) do
     regex = ~r/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/

--- a/lib/lotus/storage/query.ex
+++ b/lib/lotus/storage/query.ex
@@ -75,6 +75,7 @@ defmodule Lotus.Storage.Query do
     |> maybe_add_unique_constraint()
   end
 
+  @spec to_sql_params(t(), map()) :: {String.t(), [term()]}
   def to_sql_params(%__MODULE__{statement: sql, variables: vars} = q, supplied_vars \\ %{}) do
     regex = ~r/\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}/
 
@@ -99,6 +100,15 @@ defmodule Lotus.Storage.Query do
         acc_params ++ [cast_value(value, type)]
       }
     end)
+  end
+
+  @spec extract_variables_from_statement(String.t()) :: [String.t()]
+  def extract_variables_from_statement(statement) do
+    regex = ~r/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/
+
+    Regex.scan(regex, statement, capture: :all_but_first)
+    |> List.flatten()
+    |> Enum.uniq()
   end
 
   defp cast_value(value, :number) when is_binary(value), do: String.to_integer(value)

--- a/lib/lotus/storage/query_variable.ex
+++ b/lib/lotus/storage/query_variable.ex
@@ -82,6 +82,27 @@ defmodule Lotus.Storage.QueryVariable do
     end
   end
 
+  @doc """
+  Determines the source of options for a query variable.
+
+  Returns `:query` if the variable has a non-empty `options_query`, 
+  otherwise returns `:static`.
+
+  ## Examples
+
+      iex> var = %Lotus.Storage.QueryVariable{options_query: "SELECT id, name FROM users"}
+      iex> Lotus.Storage.QueryVariable.get_option_source(var)
+      :query
+
+      iex> var = %Lotus.Storage.QueryVariable{options_query: "   "}
+      iex> Lotus.Storage.QueryVariable.get_option_source(var)
+      :static
+
+      iex> var = %Lotus.Storage.QueryVariable{static_options: ["a", "b"]}
+      iex> Lotus.Storage.QueryVariable.get_option_source(var)
+      :static
+
+  """
   @spec get_option_source(t()) :: :query | :static
   def get_option_source(%__MODULE__{options_query: q}) when is_binary(q) do
     if String.trim(q) != "" do

--- a/lib/lotus/storage/query_variable.ex
+++ b/lib/lotus/storage/query_variable.ex
@@ -81,4 +81,15 @@ defmodule Lotus.Storage.QueryVariable do
       changeset
     end
   end
+
+  @spec get_option_source(t()) :: :query | :static
+  def get_option_source(%__MODULE__{options_query: q}) when is_binary(q) do
+    if String.trim(q) != "" do
+      :query
+    else
+      :static
+    end
+  end
+
+  def get_option_source(_), do: :static
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus"
-  @version "0.5.2"
+  @version "0.5.3"
 
   def project do
     [

--- a/test/lotus/adapter_test.exs
+++ b/test/lotus/adapter_test.exs
@@ -127,8 +127,8 @@ defmodule Lotus.AdapterTest do
   describe "param_placeholder/4" do
     @tag :postgres
     test "returns postgres placeholders with $N" do
-      assert Adapter.param_placeholder(Lotus.Test.Repo, 1, "id", :integer) == "$1"
-      assert Adapter.param_placeholder(Lotus.Test.Repo, 2, "id", :integer) == "$2"
+      assert Adapter.param_placeholder(Lotus.Test.Repo, 1, "id", :integer) == "$1::integer"
+      assert Adapter.param_placeholder(Lotus.Test.Repo, 2, "id", :integer) == "$2::integer"
     end
 
     @tag :sqlite
@@ -139,12 +139,15 @@ defmodule Lotus.AdapterTest do
 
     @tag :mysql
     test "returns mysql placeholders with ?" do
-      assert Adapter.param_placeholder(Lotus.Test.MysqlRepo, 1, "id", :integer) == "?"
-      assert Adapter.param_placeholder(Lotus.Test.MysqlRepo, 2, "id", :integer) == "?"
+      assert Adapter.param_placeholder(Lotus.Test.MysqlRepo, 1, "id", :integer) ==
+               "CAST(? AS SIGNED)"
+
+      assert Adapter.param_placeholder(Lotus.Test.MysqlRepo, 2, "id", :integer) ==
+               "CAST(? AS SIGNED)"
     end
 
     test "defaults to Postgres when repo is nil" do
-      assert Adapter.param_placeholder(nil, 1, "id", :integer) == "$1"
+      assert Adapter.param_placeholder(nil, 1, "id", :integer) == "$1::integer"
     end
   end
 end

--- a/test/lotus/storage/query_test.exs
+++ b/test/lotus/storage/query_test.exs
@@ -173,7 +173,7 @@ defmodule Lotus.Storage.QueryTest do
 
       {sql, params} = Query.to_sql_params(q, %{})
 
-      assert sql == "SELECT * FROM users WHERE age > $1"
+      assert sql == "SELECT * FROM users WHERE age > $1::numeric"
       assert params == [40]
     end
 
@@ -452,7 +452,7 @@ defmodule Lotus.Storage.QueryTest do
 
       {sql, params} = Query.to_sql_params(q, %{})
 
-      assert sql == "SELECT * FROM users WHERE age > $1"
+      assert sql == "SELECT * FROM users WHERE age > $1::numeric"
       assert params == [30]
     end
 
@@ -467,7 +467,7 @@ defmodule Lotus.Storage.QueryTest do
 
       {sql, params} = Query.to_sql_params(q, %{})
 
-      assert sql == "SELECT * FROM users WHERE created_at >= $1"
+      assert sql == "SELECT * FROM users WHERE created_at >= $1::date"
       assert params == [~D[2024-01-01]]
     end
 
@@ -498,7 +498,7 @@ defmodule Lotus.Storage.QueryTest do
 
       {sql, params} = Query.to_sql_params(q, %{"min_age" => "25", "since" => "2024-06-01"})
 
-      assert sql == "SELECT * FROM users WHERE age > $1 AND created_at >= $2"
+      assert sql == "SELECT * FROM users WHERE age > $1::numeric AND created_at >= $2::date"
       assert params == [25, ~D[2024-06-01]]
     end
 
@@ -513,7 +513,7 @@ defmodule Lotus.Storage.QueryTest do
 
       {sql, params} = Query.to_sql_params(q, %{"min_age" => "45"})
 
-      assert sql == "SELECT * FROM users WHERE age > $1"
+      assert sql == "SELECT * FROM users WHERE age > $1::numeric"
       assert params == [45]
     end
 
@@ -598,7 +598,7 @@ defmodule Lotus.Storage.QueryTest do
         })
 
       expected_sql =
-        "SELECT u.* FROM users u\nWHERE u.org_id = $1\n  AND u.created_at >= $2\n  AND u.status = $3\n  AND u.age > $4"
+        "SELECT u.* FROM users u\nWHERE u.org_id = $1::numeric\n  AND u.created_at >= $2::date\n  AND u.status = $3\n  AND u.age > $4::numeric"
 
       assert sql == expected_sql
       assert params == [5, ~D[2024-06-01], "pending", 25]

--- a/test/lotus/storage/query_variable_test.exs
+++ b/test/lotus/storage/query_variable_test.exs
@@ -1,0 +1,42 @@
+defmodule Lotus.Storage.QueryTest do
+  use Lotus.Case, async: true
+
+  alias Lotus.Storage.QueryVariable
+
+  describe "get_option_source/1" do
+    test "return :query when it has an options_query" do
+      var = build_var(options_query: "SELECT id, name FROM users ORDER BY name")
+      assert :query == QueryVariable.get_option_source(var)
+    end
+
+    test "returns :static when static_options non-empty" do
+      var = build_var(static_options: ~w(one two))
+      assert :static == QueryVariable.get_option_source(var)
+    end
+
+    test "returns :static when neither query nor static options" do
+      var = build_var()
+      assert :static == QueryVariable.get_option_source(var)
+    end
+
+    test "treats blank options_query as static" do
+      var = build_var(options_query: "   ")
+      assert :static == QueryVariable.get_option_source(var)
+    end
+  end
+
+  def build_var(applicant, attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        name: "var",
+        type: :text,
+        widget: :input,
+        label: "Var",
+        default: nil,
+        static_options: [],
+        options_query: nil
+      })
+
+    struct(QueryVariable, attrs)
+  end
+end

--- a/test/lotus/storage/query_variable_test.exs
+++ b/test/lotus/storage/query_variable_test.exs
@@ -1,4 +1,4 @@
-defmodule Lotus.Storage.QueryTest do
+defmodule Lotus.Storage.QueryVariableTest do
   use Lotus.Case, async: true
 
   alias Lotus.Storage.QueryVariable
@@ -25,7 +25,7 @@ defmodule Lotus.Storage.QueryTest do
     end
   end
 
-  def build_var(applicant, attrs \\ %{}) do
+  def build_var(attrs \\ %{}) do
     attrs =
       Enum.into(attrs, %{
         name: "var",


### PR DESCRIPTION
- Added type-specific SQL parameter placeholders for MySQL adapter supporting date, datetime, time, number, integer, boolean, and json types
- Added type-specific SQL parameter placeholders for PostgreSQL adapter supporting date, datetime, time, number, integer, boolean, and json types
- Added `extract_variables_from_statement/1` function to extract unique variable names from SQL statements in order of first occurrence
- Added `get_option_source/1` function to QueryVariable module to determine if options come from query or static sources
