### PR TITLE
Fixed Cachex v4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
   - Configured selective exclusions for `MapJoin` warnings where readability is prioritized
   - Enhanced code maintainability and testability without changing public APIs
 
+### Fixed
+
+- Fixed Cachex v4 compatibility: removed deprecated `import Cachex.Spec` and updated router configuration to v4 tuple syntax
+- Added `@compile {:no_warn_undefined, Cachex}` to suppress compiler warnings when Cachex (optional dependency) is not installed
+
 ## [0.9.2] - 2025-09-07
 
 - Added `Lotus.Export.stream_csv/2` to export the full result page by page

--- a/lib/lotus/cache/cachex.ex
+++ b/lib/lotus/cache/cachex.ex
@@ -17,9 +17,9 @@ defmodule Lotus.Cache.Cachex do
 
   use Lotus.Cache.Adapter
 
-  import Cachex.Spec
-
   alias Lotus.Config
+
+  @compile {:no_warn_undefined, Cachex}
 
   @cache_name :lotus_cache
   @tag_cache_name :lotus_cache_tags
@@ -34,7 +34,7 @@ defmodule Lotus.Cache.Cachex do
     cachex_opts =
       case Config.cache_config() do
         %{cachex_opts: opts} when is_list(opts) -> opts
-        _ -> [router: router(module: Cachex.Router.Ring, options: [monitor: true])]
+        _ -> [router: {Cachex.Router.Ring, [monitor: true]}]
       end
 
     [


### PR DESCRIPTION
## Summary

Fix Cachex v4 compatibility in Lotus.Cache.Cachex adapter. The library declared {:cachex, "~> 4.0"} as a dependency but was using the v3.x API Cachex.Spec module and old router syntax), causing compilation errors.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

 - Removed import Cachex.Spec (module was removed in Cachex v4)
  - Updated router configuration from router(module: Cachex.Router.Ring, 
  options: [monitor: true]) to {Cachex.Router.Ring, [monitor: true]} (v4 tuple
  syntax)
  - Added @compile {:no_warn_undefined, Cachex} to suppress compiler warnings
  when the optional Cachex dependency is not installed

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes manually

## Environment (if applicable)

**Elixir & OTP versions:** <!-- e.g., Elixir 1.18.3, OTP 27 -->

**Dependencies:** <!-- Any relevant dependency changes -->

## Documentation

- [ ] This change requires documentation updates
- [ ] Documentation has been updated
- [X] No documentation changes needed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked that this change doesn't introduce security vulnerabilities