### PR TITLE
Wrap Lotus.Cache.Cachex in Code.ensure_loaded? block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **NEW:** `Lotus.Cache.Cachex` adapter for local or distributed in-memory caching using [Cachex](https://hexdocs.pm/cachex/)
 - **NEW:** Query visualization storage with renderer-agnostic config DSL
 - **NEW:** `Lotus.Viz` module for visualization CRUD operations
 - **NEW:** Visualization config validation against query results

--- a/lib/lotus/cache/cachex.ex
+++ b/lib/lotus/cache/cachex.ex
@@ -1,143 +1,140 @@
-defmodule Lotus.Cache.Cachex do
-  @moduledoc """
-  A Cachex-based, local or distributed, in-memory cache adapter for Lotus.
+if Code.ensure_loaded?(Cachex) do
+  defmodule Lotus.Cache.Cachex do
+    @moduledoc """
+    A Cachex-based, local or distributed, in-memory cache adapter for Lotus.
 
-  This adapter requires the `Cachex` library. Please add `{:cachex, "~> 4.0"}` to your dependencies.
+    This adapter requires the `Cachex` library. Please add `{:cachex, "~> 4.0"}` to your dependencies.
 
-  Example configuration in `config/config.exs`:
+    Example configuration in `config/config.exs`:
 
-      config :lotus, :cache,
-        adapter: Lotus.Cache.Cachex,
-        cachex_opts: [limit: 1_000_000] # Optional Cachex options
+        config :lotus, :cache,
+          adapter: Lotus.Cache.Cachex,
+          cachex_opts: [limit: 1_000_000] # Optional Cachex options
 
-  See [Cachex documentation](https://hexdocs.pm/cachex/) for available options. By default,
-  Cachex will use a local-only routing strategy. To enable distributed caching, you can
-  choose your preferred router by [following the instructions in the Cachex docs](https://hexdocs.pm/cachex/cache-routers.html#default-routers).
-  """
+    See [Cachex documentation](https://hexdocs.pm/cachex/) for available options. By default,
+    Cachex will use a local-only routing strategy. To enable distributed caching, you can
+    choose your preferred router by [following the instructions in the Cachex docs](https://hexdocs.pm/cachex/cache-routers.html#default-routers).
+    """
 
-  use Lotus.Cache.Adapter
+    use Lotus.Cache.Adapter
 
-  import Cachex.Spec
+    import Cachex.Spec
 
-  alias Lotus.Config
+    alias Lotus.Config
 
-  @cache_name :lotus_cache
-  @tag_cache_name :lotus_cache_tags
+    @cache_name :lotus_cache
+    @tag_cache_name :lotus_cache_tags
 
-  @impl Lotus.Cache.Adapter
-  def spec_config do
-    Code.ensure_loaded?(Cachex) or
-      raise """
-      Cachex is not available. Please add {:cachex, "~> 4.0"} to your dependencies.
-      """
+    @impl Lotus.Cache.Adapter
+    def spec_config do
+      cachex_opts =
+        case Config.cache_config() do
+          %{cachex_opts: opts} when is_list(opts) -> opts
+          _ -> [router: router(module: Cachex.Router.Ring, options: [monitor: true])]
+        end
 
-    cachex_opts =
-      case Config.cache_config() do
-        %{cachex_opts: opts} when is_list(opts) -> opts
-        _ -> [router: router(module: Cachex.Router.Ring, options: [monitor: true])]
-      end
-
-    [
-      Supervisor.child_spec({Cachex, [name: @cache_name] ++ [cachex_opts]},
-        id: {Cachex, @cache_name}
-      ),
-      Supervisor.child_spec({Cachex, [name: @tag_cache_name] ++ [cachex_opts]},
-        id: {Cachex, @tag_cache_name}
-      )
-    ]
-  end
-
-  @impl Lotus.Cache.Adapter
-  def get(key) do
-    case Cachex.get(@cache_name, key) do
-      {:ok, nil} -> :miss
-      {:ok, value} -> {:ok, decode(value)}
+      [
+        Supervisor.child_spec({Cachex, [name: @cache_name] ++ [cachex_opts]},
+          id: {Cachex, @cache_name}
+        ),
+        Supervisor.child_spec({Cachex, [name: @tag_cache_name] ++ [cachex_opts]},
+          id: {Cachex, @tag_cache_name}
+        )
+      ]
     end
-  end
 
-  @impl Lotus.Cache.Adapter
-  def put(key, value, ttl_ms, opts) do
-    compress = Keyword.get(opts, :compress, true)
-    encoded = encode(value, compress)
-    max_bytes = Keyword.get(opts, :max_bytes, 5_000_000)
-
-    if byte_size(encoded) <= max_bytes do
-      case Cachex.put(@cache_name, key, encoded, expire: ttl_ms) do
-        {:ok, true} ->
-          tags = Keyword.get(opts, :tags)
-          store_tags(tags, key)
-
-          :ok
-
-        {:ok, false} ->
-          {:error, :put_failed}
+    @impl Lotus.Cache.Adapter
+    def get(key) do
+      case Cachex.get(@cache_name, key) do
+        {:ok, nil} -> :miss
+        {:ok, value} -> {:ok, decode(value)}
       end
-    else
+    end
+
+    @impl Lotus.Cache.Adapter
+    def put(key, value, ttl_ms, opts) do
+      compress = Keyword.get(opts, :compress, true)
+      encoded = encode(value, compress)
+      max_bytes = Keyword.get(opts, :max_bytes, 5_000_000)
+
+      if byte_size(encoded) <= max_bytes do
+        case Cachex.put(@cache_name, key, encoded, expire: ttl_ms) do
+          {:ok, true} ->
+            tags = Keyword.get(opts, :tags)
+            store_tags(tags, key)
+
+            :ok
+
+          {:ok, false} ->
+            {:error, :put_failed}
+        end
+      else
+        :ok
+      end
+    end
+
+    @impl Lotus.Cache.Adapter
+    def delete(key) do
+      Cachex.del(@cache_name, key)
+
       :ok
     end
-  end
 
-  @impl Lotus.Cache.Adapter
-  def delete(key) do
-    Cachex.del(@cache_name, key)
+    @impl Lotus.Cache.Adapter
+    def get_or_store(key, ttl_ms, fun, opts) do
+      case get(key) do
+        {:ok, value} ->
+          {:ok, value, :hit}
 
-    :ok
-  end
+        :miss ->
+          value = fun.()
+          put(key, value, ttl_ms, opts)
 
-  @impl Lotus.Cache.Adapter
-  def get_or_store(key, ttl_ms, fun, opts) do
-    case get(key) do
-      {:ok, value} ->
-        {:ok, value, :hit}
-
-      :miss ->
-        value = fun.()
-        put(key, value, ttl_ms, opts)
-
-        {:ok, value, :miss}
+          {:ok, value, :miss}
+      end
     end
+
+    @impl Lotus.Cache.Adapter
+    def invalidate_tags(tags) do
+      Cachex.transaction(@tag_cache_name, tags, fn tag_cache ->
+        for tag <- tags do
+          tag_cache
+          |> Cachex.get(tag)
+          |> delete_tagged_keys()
+        end
+      end)
+
+      :ok
+    end
+
+    defp delete_tagged_keys({:ok, keys}) when is_list(keys) do
+      Cachex.transaction(@cache_name, keys, fn key_cache ->
+        for key <- keys do
+          Cachex.del(key_cache, key)
+        end
+      end)
+    end
+
+    defp delete_tagged_keys(_), do: :noop
+
+    @impl Lotus.Cache.Adapter
+    def touch(key, ttl_ms) do
+      Cachex.expire(@cache_name, key, ttl_ms)
+
+      :ok
+    end
+
+    defp store_tags(tags, key) when is_list(tags) do
+      Cachex.transaction(@tag_cache_name, tags, fn cache ->
+        for tag <- tags do
+          Cachex.get_and_update(cache, tag, fn
+            nil -> {:commit, [key]}
+            existing_keys -> {:commit, [key | existing_keys]}
+          end)
+        end
+      end)
+    end
+
+    defp store_tags(nil, _key), do: :ok
   end
-
-  @impl Lotus.Cache.Adapter
-  def invalidate_tags(tags) do
-    Cachex.transaction(@tag_cache_name, tags, fn tag_cache ->
-      for tag <- tags do
-        tag_cache
-        |> Cachex.get(tag)
-        |> delete_tagged_keys()
-      end
-    end)
-
-    :ok
-  end
-
-  defp delete_tagged_keys({:ok, keys}) when is_list(keys) do
-    Cachex.transaction(@cache_name, keys, fn key_cache ->
-      for key <- keys do
-        Cachex.del(key_cache, key)
-      end
-    end)
-  end
-
-  defp delete_tagged_keys(_), do: :noop
-
-  @impl Lotus.Cache.Adapter
-  def touch(key, ttl_ms) do
-    Cachex.expire(@cache_name, key, ttl_ms)
-
-    :ok
-  end
-
-  defp store_tags(tags, key) when is_list(tags) do
-    Cachex.transaction(@tag_cache_name, tags, fn cache ->
-      for tag <- tags do
-        Cachex.get_and_update(cache, tag, fn
-          nil -> {:commit, [key]}
-          existing_keys -> {:commit, [key | existing_keys]}
-        end)
-      end
-    end)
-  end
-
-  defp store_tags(nil, _key), do: :ok
 end


### PR DESCRIPTION
## Summary

Fix compilation error when using Lotus as a dependency without `Cachex` installed. The `Lotus.Cache.Cachex` module now conditionally compiles only when `Cachex` is available, following the same pattern used for other optional dependencies in the codebase.

## Type of change

<!-- Please check one that applies to this PR -->

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

- Wrapped the entire `Lotus.Cache.Cachex` module in `if Code.ensure_loaded?(Cachex) do ... end`
- Removed the redundant runtime `Code.ensure_loaded?(Cachex)` check inside `spec_config/0`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have tested the changes manually

## Documentation

- [ ] This change requires documentation updates
- [ ] Documentation has been updated
- [X] No documentation changes needed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked that this change doesn't introduce security vulnerabilities