### PR TITLE
Remove builtin adapter constraint

### DIFF
--- a/lib/lotus/supervisor.ex
+++ b/lib/lotus/supervisor.ex
@@ -5,9 +5,6 @@ defmodule Lotus.Supervisor do
 
   use Supervisor
 
-  alias Lotus.Cache.Cachex
-  alias Lotus.Cache.ETS
-
   @spec start_link(keyword) :: Supervisor.on_start()
   def start_link(opts \\ []) do
     case Keyword.get(opts, :supervisor_name) do
@@ -22,7 +19,7 @@ defmodule Lotus.Supervisor do
 
     children =
       case cache_conf do
-        %{adapter: adapter} when adapter in [ETS, Cachex] -> adapter.spec_config()
+        %{adapter: adapter} -> adapter.spec_config()
         nil -> []
       end
 


### PR DESCRIPTION
## Summary

Currently attempting to use a cache adapter that implements the cache adapter behavior fails. This previously worked and no longer does after updating the library version.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes made

Removes the constraint that the adapter needs to be either the ETS or Cachex adapter.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this change doesn't introduce security vulnerabilities

## Related issues

Fixes #109 