### PR TITLE
cache/ets: Fix shutdown deadlock in ETS adapter

### DIFF
--- a/lib/lotus/cache/ets.ex
+++ b/lib/lotus/cache/ets.ex
@@ -16,14 +16,13 @@ defmodule Lotus.Cache.ETS do
     %{
       id: __MODULE__,
       start: {__MODULE__, :start_link, [[]]},
-      type: :supervisor
+      type: :worker
     }
   end
 
   def start_link(_opts) do
     ensure_tables!()
     start_janitor()
-    {:ok, self()}
   end
 
   @impl Lotus.Cache.Adapter
@@ -141,8 +140,11 @@ defmodule Lotus.Cache.ETS do
     end
   end
 
+
   defp start_janitor do
-    spawn_link(fn -> janitor_loop() end)
+    Task.start_link(fn ->
+      janitor_loop()
+    end)
   end
 
   defp janitor_loop do

--- a/test/lotus/cache/ets_test.exs
+++ b/test/lotus/cache/ets_test.exs
@@ -183,7 +183,7 @@ defmodule Lotus.Cache.ETSTest do
     test "returns proper child spec" do
       spec = ETS.child_spec([])
       assert spec.id == ETS
-      assert spec.type == :supervisor
+      assert spec.type == :worker
       assert spec.start == {ETS, :start_link, [[]]}
     end
   end


### PR DESCRIPTION
## Summary

start_link returned {:ok, self()}, handing the supervisor its own PID as the child. Combined with type: :supervisor (which defaults to shutdown: :infinity), the supervisor deadlocked trying to terminate itself.

Use Task.start_link for the janitor so start_link returns an actual child PID, and declare type: :worker so shutdown has a finite timeout.

## Type of change

<!-- Please check one that applies to this PR -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

Changes `Lotus.Cache.ETS` from a supervisor to a worker. Uses `Task.start_link` to produce a new pid.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

I did not introduce a test for the shutdown behavior. Instead, I explicitly set type to `worker` in the `child_spec` so that it would receive default shutdown timeout.

## Environment (if applicable)

**Elixir & OTP versions:** Elixir 1.19.5, OTP 28

**Dependencies:** <!-- Any relevant dependency changes -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here -->

## Documentation

<!-- Check if documentation needs to be updated -->

- [ ] This change requires documentation updates
- [ ] Documentation has been updated
- [x] No documentation changes needed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that this change doesn't introduce security vulnerabilities

## Related issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

fixes #219

## Additional context

<!-- Add any other context, screenshots, or information about the PR here -->