### PR TITLE
fix mysql migrations not running

### DIFF
--- a/lib/lotus/migrations.ex
+++ b/lib/lotus/migrations.ex
@@ -73,6 +73,7 @@ defmodule Lotus.Migrations do
     case repo().__adapter__() do
       Ecto.Adapters.Postgres -> Lotus.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> Lotus.Migrations.SQLite
+      Ecto.Adapters.MyXQL -> Lotus.Migrations.MySQL
       _ -> raise ArgumentError, "Unsupported database adapter: #{inspect(repo().__adapter__())}"
     end
   end


### PR DESCRIPTION
## Summary

I tried to run your installation migrations on MariaDb. It fails with MyXQL not being supported. You manually test your mysql migrations in your test suite, so I'm guessing this path isn't tested anywhere. 
## Type of change

<!-- Please check one that applies to this PR -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Changes made

I added the missing case statement


## Testing


- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

## Environment (if applicable)

**Elixir & OTP versions:** <!-- e.g., Elixir 1.18.3, OTP 27 -->

**Dependencies:** <!-- Any relevant dependency changes -->

## Breaking changes

<!-- If this PR introduces breaking changes, describe them here -->

## Documentation

<!-- Check if documentation needs to be updated -->

- [ ] This change requires documentation updates
- [ ] Documentation has been updated
- [ ] No documentation changes needed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have checked that this change doesn't introduce security vulnerabilities

## Related issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Additional context

<!-- Add any other context, screenshots, or information about the PR here -->