### PR TITLE
Prepare v0.16.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.16.5] - 2026-05-02
+
+### Fixed
+
+- **FIX:** `Lotus.Migrations` now maps the Ecto MyXQL adapter to the Lotus MySQL migration adapter, so MySQL hosts can run `Lotus.Migrations.up/0` and `down/0` correctly (#223)
+
 ## [0.16.4] - 2026-03-10
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus"
-  @version "0.16.4"
+  @version "0.16.5"
 
   def project do
     [


### PR DESCRIPTION
Bumps to v0.16.5.

### Fixed

- **FIX:** `Lotus.Migrations` now maps the Ecto MyXQL adapter to the Lotus MySQL migration adapter, so MySQL hosts can run `Lotus.Migrations.up/0` and `down/0` correctly (#223)