### PR TITLE
Cherry-pick #223 to main: MySQL migrations adapter mapping

### DIFF
--- a/lib/lotus/migrations.ex
+++ b/lib/lotus/migrations.ex
@@ -73,6 +73,7 @@ defmodule Lotus.Migrations do
     case repo().__adapter__() do
       Ecto.Adapters.Postgres -> Lotus.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> Lotus.Migrations.SQLite
+      Ecto.Adapters.MyXQL -> Lotus.Migrations.MySQL
       _ -> raise ArgumentError, "Unsupported database adapter: #{inspect(repo().__adapter__())}"
     end
   end

--- a/test/lotus/migrations/mysql_test.exs
+++ b/test/lotus/migrations/mysql_test.exs
@@ -18,8 +18,8 @@ defmodule Lotus.Migrations.MySQLTest do
   defmodule Migration do
     use Ecto.Migration
 
-    defdelegate up, to: Lotus.Migrations.MySQL
-    defdelegate down, to: Lotus.Migrations.MySQL
+    defdelegate up, to: Lotus.Migrations
+    defdelegate down, to: Lotus.Migrations
   end
 
   test "migrating a mysql database" do
@@ -27,10 +27,10 @@ defmodule Lotus.Migrations.MySQLTest do
 
     start_supervised!(MigrationRepo)
 
-    assert Ecto.Migrator.up(MigrationRepo, 1, Migration) in [:ok, :already_up]
+    assert Ecto.Migrator.up(MigrationRepo, 1, Lotus.Migrations) in [:ok, :already_up]
     assert table_exists?("lotus_queries")
 
-    assert :ok = Ecto.Migrator.down(MigrationRepo, 1, Migration)
+    assert :ok = Ecto.Migrator.down(MigrationRepo, 1, Lotus.Migrations)
     refute table_exists?("lotus_queries")
   after
     MigrationRepo.__adapter__().storage_down(MigrationRepo.config())

--- a/test/lotus/migrations/postgres_test.exs
+++ b/test/lotus/migrations/postgres_test.exs
@@ -13,23 +13,16 @@ defmodule Lotus.Migrations.PostgresTest do
     end
   end
 
-  defmodule Migration do
-    use Ecto.Migration
-
-    defdelegate up, to: Lotus.Migrations.Postgres
-    defdelegate down, to: Lotus.Migrations.Postgres
-  end
-
   test "migrating a postgres database" do
     MigrationRepo.__adapter__().storage_down(MigrationRepo.config())
     MigrationRepo.__adapter__().storage_up(MigrationRepo.config())
 
     start_supervised!(MigrationRepo)
 
-    assert Ecto.Migrator.up(MigrationRepo, 1, Migration) in [:ok, :already_up]
+    assert Ecto.Migrator.up(MigrationRepo, 1, Lotus.Migrations) in [:ok, :already_up]
     assert table_exists?("lotus_queries")
 
-    assert :ok = Ecto.Migrator.down(MigrationRepo, 1, Migration)
+    assert :ok = Ecto.Migrator.down(MigrationRepo, 1, Lotus.Migrations)
     refute table_exists?("lotus_queries")
   after
     clear_migrated()
@@ -39,8 +32,8 @@ defmodule Lotus.Migrations.PostgresTest do
   defp table_exists?(table_name) do
     query = """
     SELECT EXISTS (
-      SELECT FROM information_schema.tables 
-      WHERE table_schema = 'public' 
+      SELECT FROM information_schema.tables
+      WHERE table_schema = 'public'
       AND table_name = $1
     )
     """

--- a/test/lotus/migrations/sqlite_test.exs
+++ b/test/lotus/migrations/sqlite_test.exs
@@ -20,13 +20,6 @@ defmodule Lotus.Migrations.SQLiteTest do
 
   @moduletag :sqlite
 
-  defmodule Migration do
-    use Ecto.Migration
-
-    defdelegate up, to: Lotus.Migrations.SQLite
-    defdelegate down, to: Lotus.Migrations.SQLite
-  end
-
   test "migrating a sqlite database" do
     {:ok, _} = start_supervised(MigrationRepo)
 
@@ -36,10 +29,10 @@ defmodule Lotus.Migrations.SQLiteTest do
 
     :ok = MigrationRepo.__adapter__().storage_up(config)
 
-    assert Ecto.Migrator.up(MigrationRepo, 1, Migration) in [:ok, :already_up]
+    assert Ecto.Migrator.up(MigrationRepo, 1, Lotus.Migrations) in [:ok, :already_up]
     assert table_exists?("lotus_queries")
 
-    assert :ok = Ecto.Migrator.down(MigrationRepo, 1, Migration)
+    assert :ok = Ecto.Migrator.down(MigrationRepo, 1, Lotus.Migrations)
     refute table_exists?("lotus_queries")
   after
     try do


### PR DESCRIPTION
Ports #223 from `release/v0.16.x` to `main`.

Cherry-picked from b144380. Originally shipped in v0.16.5.