### PR TITLE
fix(cache): make Lotus.Cache.ETS a proper GenServer so shutdown doesn't hang

### DIFF
--- a/lib/lotus/cache/ets.ex
+++ b/lib/lotus/cache/ets.ex
@@ -7,23 +7,49 @@ defmodule Lotus.Cache.ETS do
   If you want a distributed cache, consider using `Lotus.Cache.Cachex`.
   """
 
+  use GenServer
   use Lotus.Cache.Adapter
 
   @table :lotus_cache
   @tag_table :lotus_cache_tags
+  @janitor_interval :timer.seconds(30)
 
-  def child_spec(_opts \\ []) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, [[]]},
-      type: :supervisor
-    }
+  def start_link(opts \\ []) do
+    case GenServer.start_link(__MODULE__, opts, name: __MODULE__) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      error -> error
+    end
   end
 
-  def start_link(_opts) do
-    ensure_tables!()
-    start_janitor()
-    {:ok, self()}
+  @impl GenServer
+  def init(_opts) do
+    :ets.new(@table, [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    :ets.new(@tag_table, [:bag, :named_table, :public, write_concurrency: true])
+
+    schedule_janitor()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:run_janitor, state) do
+    now = now_ms()
+    :ets.select_delete(@table, [{{:"$1", :"$2", :"$3"}, [{:"=<", :"$3", now}], [true]}])
+    schedule_janitor()
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp schedule_janitor do
+    Process.send_after(self(), :run_janitor, @janitor_interval)
   end
 
   @impl Lotus.Cache.Adapter
@@ -123,37 +149,6 @@ defmodule Lotus.Cache.ETS do
     end
 
     :ok
-  end
-
-  defp ensure_tables! do
-    unless :ets.whereis(@table) != :undefined do
-      :ets.new(@table, [
-        :set,
-        :named_table,
-        :public,
-        read_concurrency: true,
-        write_concurrency: true
-      ])
-    end
-
-    unless :ets.whereis(@tag_table) != :undefined do
-      :ets.new(@tag_table, [:bag, :named_table, :public, write_concurrency: true])
-    end
-  end
-
-  defp start_janitor do
-    spawn_link(fn -> janitor_loop() end)
-  end
-
-  defp janitor_loop do
-    Process.sleep(:timer.seconds(30))
-    now = now_ms()
-
-    for {key, _v, expires_at} <- :ets.tab2list(@table), expires_at <= now do
-      :ets.delete(@table, key)
-    end
-
-    janitor_loop()
   end
 
   defp expired?(ts), do: ts <= now_ms()

--- a/test/integration/caching_test.exs
+++ b/test/integration/caching_test.exs
@@ -11,8 +11,7 @@ defmodule Lotus.Integration.CachingTest do
     Mimic.copy(Lotus.Config)
     Mimic.copy(Lotus.Cache)
 
-    cleanup_cache_tables()
-    {:ok, _} = ETS.start_link([])
+    start_supervised!(ETS)
 
     Config
     |> stub(:cache_adapter, fn -> {:ok, ETS} end)
@@ -40,26 +39,7 @@ defmodule Lotus.Integration.CachingTest do
       end
     end)
 
-    on_exit(fn -> cleanup_cache_tables() end)
     :ok
-  end
-
-  defp cleanup_cache_tables do
-    try do
-      if :ets.whereis(:lotus_cache) != :undefined do
-        :ets.delete(:lotus_cache)
-      end
-    rescue
-      ArgumentError -> :ok
-    end
-
-    try do
-      if :ets.whereis(:lotus_cache_tags) != :undefined do
-        :ets.delete(:lotus_cache_tags)
-      end
-    rescue
-      ArgumentError -> :ok
-    end
   end
 
   describe "run_sql/3 caching scenarios" do

--- a/test/lotus/cache/ets_test.exs
+++ b/test/lotus/cache/ets_test.exs
@@ -180,31 +180,27 @@ defmodule Lotus.Cache.ETSTest do
   end
 
   describe "child_spec/1" do
-    test "returns proper child spec" do
+    test "returns the default GenServer child spec" do
       spec = ETS.child_spec([])
       assert spec.id == ETS
-      assert spec.type == :supervisor
       assert spec.start == {ETS, :start_link, [[]]}
     end
   end
 
   describe "start_link/1" do
-    test "creates ETS tables and starts successfully" do
-      if :ets.whereis(:lotus_cache) != :undefined do
-        :ets.delete(:lotus_cache)
-      end
-
-      if :ets.whereis(:lotus_cache_tags) != :undefined do
-        :ets.delete(:lotus_cache_tags)
-      end
-
-      assert {:ok, _pid} = ETS.start_link([])
-      assert :ets.whereis(:lotus_cache) != :undefined
-      assert :ets.whereis(:lotus_cache_tags) != :undefined
+    test "is idempotent when the singleton is already started" do
+      # Lotus.Application starts ETS as a named singleton. A second start_link
+      # should return {:ok, pid} rather than {:error, {:already_started, _}}.
+      assert {:ok, pid1} = ETS.start_link([])
+      assert {:ok, pid2} = ETS.start_link([])
+      assert pid1 == pid2
+      assert Process.alive?(pid1)
     end
 
-    test "handles already existing tables gracefully" do
-      assert {:ok, _pid} = ETS.start_link([])
+    test "cache tables are live and usable" do
+      assert :ets.whereis(:lotus_cache) != :undefined
+      assert :ets.whereis(:lotus_cache_tags) != :undefined
+
       ETS.put("test", "value", 5000, [])
       assert ETS.get("test") == {:ok, "value"}
     end

--- a/test/support/cache_case.ex
+++ b/test/support/cache_case.ex
@@ -1,11 +1,13 @@
 defmodule Lotus.CacheCase do
   @moduledoc """
   This module defines the setup for cache-related tests.
+
+  `Lotus.Cache.ETS` is a named GenServer that owns the cache tables. ExUnit
+  starts a supervised instance per test, which guarantees the GenServer (and
+  its ETS tables) are torn down cleanly between tests.
   """
 
   use ExUnit.CaseTemplate
-
-  alias Lotus.Cache.ETS
 
   using do
     quote do
@@ -14,30 +16,7 @@ defmodule Lotus.CacheCase do
   end
 
   setup do
-    cleanup_cache_tables()
-
-    {:ok, _} = ETS.start_link([])
-
-    on_exit(fn -> cleanup_cache_tables() end)
-
+    start_supervised!(Lotus.Cache.ETS)
     :ok
-  end
-
-  defp cleanup_cache_tables do
-    try do
-      if :ets.whereis(:lotus_cache) != :undefined do
-        :ets.delete(:lotus_cache)
-      end
-    rescue
-      ArgumentError -> :ok
-    end
-
-    try do
-      if :ets.whereis(:lotus_cache_tags) != :undefined do
-        :ets.delete(:lotus_cache_tags)
-      end
-    rescue
-      ArgumentError -> :ok
-    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #219.

`Lotus.Cache.ETS.start_link/1` did not actually start a GenServer — it created ETS tables, `spawn_link`ed a janitor loop, and returned `{:ok, self()}`. Because `start_link/1` is called inside the supervisor process, the cache "child" pid was the supervisor itself and the janitor was a plain spawn-linked process that never trapped exits. On `Application.stop/1`, the BEAM blocked waiting for the janitor to die, forcing users to send `SIGKILL`.

This PR rewrites the adapter as a proper `GenServer` that owns the ETS tables in `init/1` and schedules its janitor via `Process.send_after/3`. The supervisor now gets a real, supervised child with a clean shutdown path. This is the same shape `main` already has; the rewrite is isolated to `lib/lotus/cache/ets.ex` and does not pull in the 1.0 adapter-registry refactor.